### PR TITLE
feat(map/schedule): connected map locations to filtered schedule events

### DIFF
--- a/app/src/main/kotlin/com/ekhonavigator/EkhoNavigatorApp.kt
+++ b/app/src/main/kotlin/com/ekhonavigator/EkhoNavigatorApp.kt
@@ -68,8 +68,10 @@ fun EkhoNavigatorApp(
     val navigator = Navigator(navigationState)
 
     val currentKey = navigationState.currentKey
-    val topLevelDestination = TOP_LEVEL_NAV_ITEMS[currentKey]
+    val topLevelDestination =
+        TOP_LEVEL_NAV_ITEMS.entries.find { (key, _) -> key::class == currentKey::class }?.value
     val isTopLevelDestination = topLevelDestination != null
+    val isPureDestination = TOP_LEVEL_NAV_ITEMS.containsKey(currentKey)
 
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
@@ -87,11 +89,11 @@ fun EkhoNavigatorApp(
             EkhoTopAppBar(
                 titleRes = titleRes,
                 scrollBehavior = scrollBehavior,
-                navigationIcon = if (isTopLevelDestination) null else EkhoIcons.ArrowBack,
+                navigationIcon = if (isPureDestination) null else EkhoIcons.ArrowBack,
                 actionIcon = EkhoIcons.AccountCircle,
-                navigationIconContentDescription = if (isTopLevelDestination) null else "Back",
+                navigationIconContentDescription = if (isPureDestination) null else "Back",
                 onNavigationClick = {
-                    if (!isTopLevelDestination) {
+                    if (!isPureDestination) {
                         navigator.goBack()
                     }
                 },
@@ -236,7 +238,7 @@ private fun EkhoBottomBar(
 ) {
     EkhoNavigationBar {
         TOP_LEVEL_NAV_ITEMS.forEach { (navKey, item) ->
-            val selected = navKey == currentTopLevelKey
+            val selected = navKey::class == currentTopLevelKey::class
             EkhoNavigationBarItem(
                 selected = selected,
                 onClick = { onNavigateToNavKey(navKey) },

--- a/app/src/main/kotlin/com/ekhonavigator/EkhoNavigatorApp.kt
+++ b/app/src/main/kotlin/com/ekhonavigator/EkhoNavigatorApp.kt
@@ -22,9 +22,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.ui.NavDisplay
 import com.ekhonavigator.core.designsystem.component.EkhoNavigationBar
 import com.ekhonavigator.core.designsystem.component.EkhoNavigationBarItem
 import com.ekhonavigator.core.designsystem.component.EkhoTopAppBar
@@ -32,28 +32,28 @@ import com.ekhonavigator.core.designsystem.icon.EkhoIcons
 import com.ekhonavigator.core.navigation.Navigator
 import com.ekhonavigator.core.navigation.rememberNavigationState
 import com.ekhonavigator.core.navigation.toEntries
-import com.ekhonavigator.feature.map.MapScreen
-import com.ekhonavigator.feature.map.navigation.MapNavKey
-import com.ekhonavigator.feature.account.navigation.navigateToAccount
 import com.ekhonavigator.feature.account.AccountScreen
 import com.ekhonavigator.feature.account.navigation.AccountNavKey
-import com.ekhonavigator.feature.social.SocialScreen
-import com.ekhonavigator.feature.social.UserProfileScreen
-import com.ekhonavigator.feature.social.navigation.SocialNavKey
-import com.ekhonavigator.feature.social.navigation.UserProfileNavKey
-import com.ekhonavigator.feature.schedule.CreateEventScreen
-import com.ekhonavigator.feature.schedule.navigation.CreateEventNavKey
-import com.ekhonavigator.feature.schedule.navigation.navigateToCreateEvent
+import com.ekhonavigator.feature.account.navigation.navigateToAccount
 import com.ekhonavigator.feature.event.EventScreen
 import com.ekhonavigator.feature.event.navigation.EventNavKey
 import com.ekhonavigator.feature.event.navigation.navigateToEvent
 import com.ekhonavigator.feature.home.HomeScreen
 import com.ekhonavigator.feature.home.navigation.HomeNavKey
+import com.ekhonavigator.feature.map.MapScreen
+import com.ekhonavigator.feature.map.navigation.MapNavKey
+import com.ekhonavigator.feature.schedule.CreateEventScreen
 import com.ekhonavigator.feature.schedule.DayScreen
 import com.ekhonavigator.feature.schedule.ScheduleScreen
+import com.ekhonavigator.feature.schedule.navigation.CreateEventNavKey
 import com.ekhonavigator.feature.schedule.navigation.DayNavKey
 import com.ekhonavigator.feature.schedule.navigation.ScheduleNavKey
+import com.ekhonavigator.feature.schedule.navigation.navigateToCreateEvent
 import com.ekhonavigator.feature.schedule.navigation.navigateToDay
+import com.ekhonavigator.feature.social.SocialScreen
+import com.ekhonavigator.feature.social.UserProfileScreen
+import com.ekhonavigator.feature.social.navigation.SocialNavKey
+import com.ekhonavigator.feature.social.navigation.UserProfileNavKey
 import com.ekhonavigator.navigation.TOP_LEVEL_NAV_ITEMS
 
 @Composable
@@ -139,6 +139,7 @@ fun EkhoNavigatorApp(
                                 onCreateEventClick = { epochDay ->
                                     navigator.navigateToCreateEvent(epochDay)
                                 },
+                                initialLocationFilter = key.initialLocationFilter
                             )
                         }
                     }
@@ -168,7 +169,12 @@ fun EkhoNavigatorApp(
 
                     is MapNavKey -> {
                         NavEntry(key) {
-                            MapScreen(onEventClick = navigator::navigateToEvent)
+                            MapScreen(
+                                onEventClick = navigator::navigateToEvent,
+                                onOpenScheduleForLocation = { selectedCampusPlaceName ->
+                                    navigator.navigate(ScheduleNavKey(initialLocationFilter = selectedCampusPlaceName))
+                                }
+                            )
                         }
                     }
 

--- a/app/src/main/kotlin/com/ekhonavigator/EkhoNavigatorApp.kt
+++ b/app/src/main/kotlin/com/ekhonavigator/EkhoNavigatorApp.kt
@@ -106,7 +106,8 @@ fun EkhoNavigatorApp(
             if (isTopLevelDestination) {
                 EkhoBottomBar(
                     onNavigateToNavKey = navigator::navigate,
-                    currentTopLevelKey = navigationState.currentTopLevelKey
+                    // used currentKey so the bar knows exactly which screen is active
+                    currentTopLevelKey = currentKey
                 )
             }
         }
@@ -238,7 +239,7 @@ private fun EkhoBottomBar(
 ) {
     EkhoNavigationBar {
         TOP_LEVEL_NAV_ITEMS.forEach { (navKey, item) ->
-            val selected = navKey::class == currentTopLevelKey::class
+            val selected = navKey::class == currentTopLevelKey::class     // matched by class so the icon highlights for any version of the tab
             EkhoNavigationBarItem(
                 selected = selected,
                 onClick = { onNavigateToNavKey(navKey) },

--- a/app/src/main/kotlin/com/ekhonavigator/navigation/TopLevelNavItem.kt
+++ b/app/src/main/kotlin/com/ekhonavigator/navigation/TopLevelNavItem.kt
@@ -2,12 +2,13 @@ package com.ekhonavigator.navigation
 
 import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation3.runtime.NavKey
 import com.ekhonavigator.R
 import com.ekhonavigator.core.designsystem.icon.EkhoIcons
+import com.ekhonavigator.feature.home.navigation.HomeNavKey
+import com.ekhonavigator.feature.map.navigation.MapNavKey
 import com.ekhonavigator.feature.schedule.navigation.ScheduleNavKey
 import com.ekhonavigator.feature.social.navigation.SocialNavKey
-import com.ekhonavigator.feature.map.navigation.MapNavKey
-import com.ekhonavigator.feature.home.navigation.HomeNavKey
 
 /** UI metadata for a top-level navigation destination. */
 data class TopLevelNavItem(
@@ -41,9 +42,9 @@ val SOCIAL = TopLevelNavItem(
     label = "Social",
 )
 
-val TOP_LEVEL_NAV_ITEMS = mapOf(
+val TOP_LEVEL_NAV_ITEMS: Map<NavKey, TopLevelNavItem> = mapOf(
     HomeNavKey to HOME,
-    ScheduleNavKey to SCHEDULE,
+    ScheduleNavKey() to SCHEDULE,         // changed ScheduleNavKey from an object to a data class to allow passing locationQuery for filtering events from the map
     SocialNavKey to SOCIAL,
     MapNavKey to MAP,
 )

--- a/core/navigation/src/main/java/com/ekhonavigator/core/navigation/Navigator.kt
+++ b/core/navigation/src/main/java/com/ekhonavigator/core/navigation/Navigator.kt
@@ -32,8 +32,11 @@ class Navigator(val state: NavigationState) {
      */
     fun navigate(key: NavKey) {
         when (key) {
-            state.currentTopLevelKey -> clearSubStack()
-            in state.topLevelKeys -> goToTopLevel(key)
+            in state.topLevelKeys -> {
+                goToTopLevel(key)
+                // Always reset the tab to its root when selected from the Bottom Bar
+                clearSubStack()
+            }
             else -> goToKey(key)
         }
     }

--- a/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/LocationDetailComponents.kt
+++ b/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/LocationDetailComponents.kt
@@ -1,6 +1,8 @@
 package com.ekhonavigator.feature.map
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -82,7 +84,11 @@ fun CampusPlacePreviewCard(place: CampusPlace) {
 }
 
 @Composable
-fun CampusPlaceDetailCard(place: CampusPlace, onDismiss: () -> Unit) {
+fun CampusPlaceDetailCard(
+    place: CampusPlace,
+    onDismiss: () -> Unit,
+    onViewLocationEvents: (String) -> Unit
+) {
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false)
@@ -125,11 +131,20 @@ fun CampusPlaceDetailCard(place: CampusPlace, onDismiss: () -> Unit) {
 
                 Spacer(modifier = Modifier.height(24.dp))
 
-                Button(
-                    onClick = onDismiss,
-                    modifier = Modifier.align(Alignment.End)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
                 ) {
-                    Text("Close")
+                    androidx.compose.material3.TextButton(
+                        onClick = { onViewLocationEvents(place.name) },
+                        modifier = Modifier.padding(end = 8.dp)
+                    ) {
+                        Text("View Events Here")
+                    }
+
+                    Button(onClick = onDismiss) {
+                        Text("Close")
+                    }
                 }
             }
         }

--- a/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/MapScreen.kt
@@ -139,6 +139,7 @@ fun MapLocationControls(
 @Composable
 fun MapScreen(
     onEventClick: (String) -> Unit,
+    onOpenScheduleForLocation: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: MapViewModel = hiltViewModel()
 ) {
@@ -495,7 +496,11 @@ fun MapScreen(
         selectedCampusPlace?.let { place ->
             CampusPlaceDetailCard(
                 place = place,
-                onDismiss = { selectedCampusPlace = null }
+                onDismiss = { selectedCampusPlace = null },
+                onViewLocationEvents = { selectedLocationName ->
+                    selectedCampusPlace = null
+                    onOpenScheduleForLocation(selectedLocationName)
+                }
             )
         }
     }

--- a/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/MapViewModel.kt
+++ b/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/MapViewModel.kt
@@ -64,10 +64,12 @@ class MapViewModel @Inject constructor(
 
     fun updateMarkerLabel(markerIdToUpdate: Long, newMarkerCommentText: String) {
         val userId = currentUserId ?: return
-        val markerIndexToUpdate = droppedMarkers.indexOfFirst { currentMarker -> currentMarker.id == markerIdToUpdate }
+        val markerIndexToUpdate =
+            droppedMarkers.indexOfFirst { currentMarker -> currentMarker.id == markerIdToUpdate }
 
         if (markerIndexToUpdate != -1) {
-            val updatedMarker = droppedMarkers[markerIndexToUpdate].copy(markerLabelComment = newMarkerCommentText)
+            val updatedMarker =
+                droppedMarkers[markerIndexToUpdate].copy(markerLabelComment = newMarkerCommentText)
             droppedMarkers[markerIndexToUpdate] = updatedMarker
 
             viewModelScope.launch {

--- a/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/navigation/MapNavKey.kt
+++ b/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/navigation/MapNavKey.kt
@@ -1,19 +1,8 @@
 package com.ekhonavigator.feature.map.navigation
 
-import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
-import com.ekhonavigator.core.navigation.Navigator
-import com.ekhonavigator.feature.map.MapScreen
-import com.ekhonavigator.feature.event.navigation.navigateToEvent
 
 @Serializable
 object MapNavKey : NavKey
 
-fun EntryProviderScope<NavKey>.mapEntry(navigator: Navigator) {
-    entry<MapNavKey> {
-        MapScreen(
-            onEventClick = navigator::navigateToEvent,
-        )
-    }
-}

--- a/feature/schedule/src/main/kotlin/com/ekhonavigator/feature/schedule/MapLocationEventsBridge.kt
+++ b/feature/schedule/src/main/kotlin/com/ekhonavigator/feature/schedule/MapLocationEventsBridge.kt
@@ -1,0 +1,21 @@
+package com.ekhonavigator.feature.schedule
+
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+
+@Composable
+fun MapLocationEventsBridge(
+    selectedLocationFilter: String?,
+    scheduleViewModel: ScheduleViewModel,
+    schedulePagerState: PagerState,
+    discoverPageIndex: Int
+) {
+    LaunchedEffect(selectedLocationFilter) {
+        // only triggers if the location name is not null or blank
+        selectedLocationFilter?.takeIf { it.isNotBlank() }?.let { selectedLocationName ->
+            scheduleViewModel.setSearchQuery(selectedLocationName)
+            schedulePagerState.scrollToPage(discoverPageIndex)
+        }
+    }
+}

--- a/feature/schedule/src/main/kotlin/com/ekhonavigator/feature/schedule/ScheduleScreen.kt
+++ b/feature/schedule/src/main/kotlin/com/ekhonavigator/feature/schedule/ScheduleScreen.kt
@@ -61,6 +61,7 @@ fun ScheduleScreen(
     onEventClick: (String) -> Unit,
     onDayClick: (Long, Set<ScheduleSourceType>, Set<EventCategory>) -> Unit,
     onCreateEventClick: (Long?) -> Unit = {},
+    initialLocationFilter: String? = null,
     modifier: Modifier = Modifier,
     viewModel: ScheduleViewModel = hiltViewModel(),
 ) {
@@ -69,6 +70,14 @@ fun ScheduleScreen(
         initialPage = ScheduleTab.DAY.ordinal,
         pageCount = { tabs.size },
     )
+
+    MapLocationEventsBridge(
+        selectedLocationFilter = initialLocationFilter,
+        scheduleViewModel = viewModel,
+        schedulePagerState = pagerState,
+        discoverPageIndex = ScheduleTab.DISCOVER.ordinal
+    )
+
     val scope = rememberCoroutineScope()
     var daySnapTrigger by remember { mutableStateOf(0) }
     var weekSnapTrigger by remember { mutableStateOf(0) }

--- a/feature/schedule/src/main/kotlin/com/ekhonavigator/feature/schedule/navigation/ScheduleNavKey.kt
+++ b/feature/schedule/src/main/kotlin/com/ekhonavigator/feature/schedule/navigation/ScheduleNavKey.kt
@@ -4,4 +4,4 @@ import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
 
 @Serializable
-object ScheduleNavKey : NavKey
+data class ScheduleNavKey(val initialLocationFilter: String? = null) : NavKey


### PR DESCRIPTION
• Added MapLocationEventsBridge to handle map-to-schedule event filtering. 
• Updated ScheduleNavKey to pass an initial location filter. 
• Added a “View Events Here” button to campus location detail cards.
• Wired map navigation to open Schedule with the selected location name. 
• Set Schedule to open on the Discover tab when a location filter is passed.