### PR TITLE
feature/sociall/messaging

### DIFF
--- a/app/src/main/kotlin/com/ekhonavigator/EkhoNavigatorApp.kt
+++ b/app/src/main/kotlin/com/ekhonavigator/EkhoNavigatorApp.kt
@@ -294,6 +294,7 @@ fun EkhoNavigatorApp(
                         NavEntry(key) {
                             UserProfileScreen(
                                 userId = key.userId,
+                                onBack = navigator::goBack,
                             )
                         }
                     }

--- a/app/src/main/kotlin/com/ekhonavigator/EkhoNavigatorApp.kt
+++ b/app/src/main/kotlin/com/ekhonavigator/EkhoNavigatorApp.kt
@@ -97,6 +97,32 @@ fun EkhoNavigatorApp(
     val isTopLevelDestination = topLevelDestination != null
     val isDefaultTopLevel = TOP_LEVEL_NAV_ITEMS.containsKey(currentKey)
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
 

--- a/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/ChatConversation.kt
+++ b/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/ChatConversation.kt
@@ -8,5 +8,6 @@ data class ChatConversation(
     val lastSenderId: String = "",
     val lastTimestamp: Long = 0L,
     val readBy: List<String> = emptyList(),
+    val unreadCount: Int = 0,
     val createdAt: Long = 0L,
 )

--- a/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/ChatRepository.kt
+++ b/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/ChatRepository.kt
@@ -173,6 +173,7 @@ class ChatRepository @Inject constructor() {
             lastSenderId = getString("lastSenderId") ?: "",
             lastTimestamp = lastTimestamp,
             readBy = (get("readBy") as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
+            unreadCount = getLong("unreadCount")?.toInt() ?: 0,
             createdAt = createdAt,
         )
     }
@@ -225,10 +226,11 @@ class ChatRepository @Inject constructor() {
         batch.update(
             conversationRef,
             mapOf(
-                "lastMessage" to trimmed,
+                "lastMessage" to (if (trimmed.isEmpty() && sharedLocation != null) "Shared a location" else trimmed),
                 "lastSenderId" to senderId,
                 "lastTimestamp" to FieldValue.serverTimestamp(),
                 "readBy" to listOf(senderId),
+                "unreadCount" to FieldValue.increment(1)
             )
         )
         batch.commit().await()
@@ -238,15 +240,33 @@ class ChatRepository @Inject constructor() {
         conversationId: String,
         currentUserId: String,
     ) {
+        val conversationRef = firestore.collection("conversations").document(conversationId)
+
+        firestore.runTransaction { transaction ->
+            val snapshot = transaction.get(conversationRef)
+            val lastSenderId = snapshot.getString("lastSenderId")
+            
+            // Only reset if the current user is NOT the last sender 
+            // OR if there is an actual unread count to clear.
+            if (lastSenderId != currentUserId) {
+                transaction.update(conversationRef, 
+                    mapOf(
+                        "readBy" to FieldValue.arrayUnion(currentUserId),
+                        "unreadCount" to 0
+                    )
+                )
+            }
+        }.await()
+
+        // Also mark individual messages as read (outside the transaction to keep it simple, 
+        // as this can be many documents)
         val messagesRef = firestore.collection("conversations")
             .document(conversationId)
             .collection("messages")
 
-        val snapshot = messagesRef.get().await()
-
+        val messageSnapshot = messagesRef.get().await()
         val batch = firestore.batch()
-
-        snapshot.documents.forEach { doc ->
+        messageSnapshot.documents.forEach { doc ->
             val senderId = doc.getString("senderId") ?: return@forEach
             val readBy = (doc.get("readBy") as? List<*>)?.filterIsInstance<String>() ?: emptyList()
 
@@ -254,10 +274,6 @@ class ChatRepository @Inject constructor() {
                 batch.update(doc.reference, "readBy", FieldValue.arrayUnion(currentUserId))
             }
         }
-
-        val conversationRef = firestore.collection("conversations").document(conversationId)
-        batch.update(conversationRef, "readBy", FieldValue.arrayUnion(currentUserId))
-
         batch.commit().await()
     }
 }

--- a/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/FriendUser.kt
+++ b/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/FriendUser.kt
@@ -15,4 +15,5 @@ data class FriendUser(
     val lastMessageSenderId: String = "",
     val hasUnreadMessages: Boolean = false,
     val unreadCount: Int = 0,
+    val showOnlineStatus: Boolean = true,
 )

--- a/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/FriendUser.kt
+++ b/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/FriendUser.kt
@@ -7,7 +7,6 @@ data class FriendUser(
     val displayName: String = "",
     val avatarId: String = "avatar_default",
     val major: String = "",
-    val showOnlineStatus: Boolean = true,
     val online: Boolean = false,
     val onlineStatus: OnlineStatus = OnlineStatus.ONLINE,
     val lastChanged: Long = 0L,

--- a/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/FriendUser.kt
+++ b/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/FriendUser.kt
@@ -15,4 +15,5 @@ data class FriendUser(
     val lastMessageTimestamp: Long = 0L,
     val lastMessageSenderId: String = "",
     val hasUnreadMessages: Boolean = false,
+    val unreadCount: Int = 0,
 )

--- a/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/SocialRepository.kt
+++ b/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/SocialRepository.kt
@@ -13,6 +13,37 @@ open class SocialRepository @Inject constructor() {
 
     private val firestore by lazy { FirebaseFirestore.getInstance() }
 
+    open fun observeUser(userId: String): Flow<SocialUser?> = callbackFlow {
+        val registration = firestore.collection("users")
+            .document(userId)
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    trySend(null)
+                    return@addSnapshotListener
+                }
+                if (snapshot == null || !snapshot.exists()) {
+                    trySend(null)
+                    return@addSnapshotListener
+                }
+
+                val user = SocialUser(
+                    id = snapshot.id,
+                    displayName = snapshot.getString("displayName") ?: "",
+                    email = snapshot.getString("email") ?: "",
+                    major = snapshot.getString("major") ?: "",
+                    description = snapshot.getString("description") ?: "",
+                    links = snapshot.getString("links") ?: "",
+                    avatarId = snapshot.getString("avatarId") ?: "avatar_default",
+                    majorVisible = snapshot.getBoolean("majorVisible") ?: false,
+                    descriptionVisible = snapshot.getBoolean("descriptionVisible") ?: false,
+                    linksVisible = snapshot.getBoolean("linksVisible") ?: false,
+                    showOnlineStatus = snapshot.getBoolean("showOnlineStatus") ?: true,
+                )
+                trySend(user)
+            }
+        awaitClose { registration.remove() }
+    }
+
     suspend fun getUserById(userId: String): SocialUser? {
         val doc = firestore.collection("users")
             .document(userId)
@@ -178,16 +209,9 @@ open class SocialRepository @Inject constructor() {
                 }
                 val friends = snapshot?.documents?.mapNotNull { doc ->
                     val uid = doc.getString("uid") ?: return@mapNotNull null
-                    val displayName = doc.getString("displayName") ?: return@mapNotNull null
-
                     if (uid == currentUserId) return@mapNotNull null
 
-                    FriendUser(
-                        uid = uid,
-                        displayName = displayName,
-                        avatarId = doc.getString("avatarId") ?: "avatar_default",
-                        major = doc.getString("major") ?: "",
-                    )
+                    FriendUser(uid = uid)
                 } ?: emptyList()
                 trySend(friends)
             }
@@ -210,39 +234,13 @@ open class SocialRepository @Inject constructor() {
 
         return snapshot.documents.mapNotNull {
             val uid = it.getString("uid") ?: return@mapNotNull null
-            val displayName = it.getString("displayName") ?: return@mapNotNull null
-
             if (uid == currentUserId) return@mapNotNull null
 
-            FriendUser(
-                uid = uid,
-                displayName = displayName,
-                avatarId = it.getString("avatarId") ?: "avatar_default",
-                major = it.getString("major") ?: "",
-            )
+            FriendUser(uid = uid)
         }
     }
 
     suspend fun acceptFriendRequest(currentUserId: String, fromUserId: String) {
-        val currentUserDoc = firestore.collection("users").document(currentUserId).get().await()
-        val fromUserDoc = firestore.collection("users").document(fromUserId).get().await()
-
-        if (!currentUserDoc.exists() || !fromUserDoc.exists()) return
-
-        val currentUserData = mapOf(
-            "uid" to currentUserId,
-            "displayName" to (currentUserDoc.getString("displayName") ?: ""),
-            "avatarId" to (currentUserDoc.getString("avatarId") ?: "avatar_default"),
-            "major" to (currentUserDoc.getString("major") ?: ""),
-        )
-
-        val fromUserData = mapOf(
-            "uid" to fromUserId,
-            "displayName" to (fromUserDoc.getString("displayName") ?: ""),
-            "avatarId" to (fromUserDoc.getString("avatarId") ?: "avatar_default"),
-            "major" to (fromUserDoc.getString("major") ?: ""),
-        )
-
         val batch = firestore.batch()
 
         val incomingRef = firestore.collection("users")
@@ -280,8 +278,8 @@ open class SocialRepository @Inject constructor() {
         batch.delete(reverseIncomingRef)
         batch.delete(reverseOutgoingRef)
 
-        batch.set(currentFriendRef, fromUserData)
-        batch.set(fromFriendRef, currentUserData)
+        batch.set(currentFriendRef, mapOf("uid" to fromUserId))
+        batch.set(fromFriendRef, mapOf("uid" to currentUserId))
 
         batch.commit().await()
     }

--- a/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/SocialRepository.kt
+++ b/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/SocialRepository.kt
@@ -167,6 +167,34 @@ open class SocialRepository @Inject constructor() {
         awaitClose { registration.remove() }
     }
 
+    open fun observeFriends(currentUserId: String): Flow<List<FriendUser>> = callbackFlow {
+        val registration = firestore.collection("users")
+            .document(currentUserId)
+            .collection("friends")
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    trySend(emptyList())
+                    return@addSnapshotListener
+                }
+                val friends = snapshot?.documents?.mapNotNull { doc ->
+                    val uid = doc.getString("uid") ?: return@mapNotNull null
+                    val displayName = doc.getString("displayName") ?: return@mapNotNull null
+
+                    if (uid == currentUserId) return@mapNotNull null
+
+                    FriendUser(
+                        uid = uid,
+                        displayName = displayName,
+                        avatarId = doc.getString("avatarId") ?: "avatar_default",
+                        major = doc.getString("major") ?: "",
+                        showOnlineStatus = doc.getBoolean("showOnlineStatus") ?: true,
+                    )
+                } ?: emptyList()
+                trySend(friends)
+            }
+        awaitClose { registration.remove() }
+    }
+
     private fun DocumentSnapshot.toFriendRequest(): FriendRequest = FriendRequest(
         uid = getString("uid") ?: "",
         displayName = getString("displayName") ?: "",

--- a/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/SocialRepository.kt
+++ b/core/data/src/main/kotlin/com/ekhonavigator/core/data/social/SocialRepository.kt
@@ -187,7 +187,6 @@ open class SocialRepository @Inject constructor() {
                         displayName = displayName,
                         avatarId = doc.getString("avatarId") ?: "avatar_default",
                         major = doc.getString("major") ?: "",
-                        showOnlineStatus = doc.getBoolean("showOnlineStatus") ?: true,
                     )
                 } ?: emptyList()
                 trySend(friends)
@@ -220,7 +219,6 @@ open class SocialRepository @Inject constructor() {
                 displayName = displayName,
                 avatarId = it.getString("avatarId") ?: "avatar_default",
                 major = it.getString("major") ?: "",
-                showOnlineStatus = it.getBoolean("showOnlineStatus") ?: true,
             )
         }
     }
@@ -236,7 +234,6 @@ open class SocialRepository @Inject constructor() {
             "displayName" to (currentUserDoc.getString("displayName") ?: ""),
             "avatarId" to (currentUserDoc.getString("avatarId") ?: "avatar_default"),
             "major" to (currentUserDoc.getString("major") ?: ""),
-            "showOnlineStatus" to (currentUserDoc.getBoolean("showOnlineStatus") ?: true),
         )
 
         val fromUserData = mapOf(
@@ -244,7 +241,6 @@ open class SocialRepository @Inject constructor() {
             "displayName" to (fromUserDoc.getString("displayName") ?: ""),
             "avatarId" to (fromUserDoc.getString("avatarId") ?: "avatar_default"),
             "major" to (fromUserDoc.getString("major") ?: ""),
-            "showOnlineStatus" to (fromUserDoc.getBoolean("showOnlineStatus") ?: true),
         )
 
         val batch = firestore.batch()

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/ChatViewModel.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/ChatViewModel.kt
@@ -111,11 +111,15 @@ class ChatViewModel @Inject constructor(
                                 )
                             }
 
-                            runCatching {
-                                chatRepository.markMessagesAsRead(
-                                    conversationId = conversation.id,
-                                    currentUserId = currentUserId,
-                                )
+                            if (messages.isNotEmpty()) {
+                                viewModelScope.launch {
+                                    runCatching {
+                                        chatRepository.markMessagesAsRead(
+                                            conversationId = conversation.id,
+                                            currentUserId = currentUserId,
+                                        )
+                                    }
+                                }
                             }
                         }
                 }

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialScreen.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialScreen.kt
@@ -153,6 +153,7 @@ fun SocialScreen(
                         major = friend.major,
                         online = friend.online,
                         onlineStatus = friend.onlineStatus,
+                        showOnlineStatus = friend.showOnlineStatus,
                         lastMessage = friend.lastMessage,
                         hasUnreadMessages = friend.hasUnreadMessages,
                         unreadCount = friend.unreadCount,
@@ -291,6 +292,7 @@ private fun FriendRow(
     major: String,
     online: Boolean,
     onlineStatus: OnlineStatus,
+    showOnlineStatus: Boolean,
     lastMessage: String,
     hasUnreadMessages: Boolean,
     unreadCount: Int,
@@ -340,7 +342,7 @@ private fun FriendRow(
                         )
                     }
 
-                    if (online) {
+                    if (online && showOnlineStatus) {
                         val statusColor = when (onlineStatus) {
                             OnlineStatus.ONLINE -> Color(0xFF4CAF50)
                             OnlineStatus.AWAY -> Color(0xFFFFC107)

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialScreen.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialScreen.kt
@@ -1,5 +1,6 @@
 package com.ekhonavigator.feature.social
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -36,10 +37,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.compose.ui.text.style.TextOverflow
 import com.ekhonavigator.core.model.OnlineStatus
+import com.ekhonavigator.core.designsystem.R as DesignR
 
 @Composable
 fun SocialScreen(
@@ -307,19 +311,21 @@ private fun FriendRow(
                     modifier = Modifier.size(40.dp),
                     contentAlignment = Alignment.BottomEnd,
                 ) {
-                    Box(
+                    val resId = when (avatarId) {
+                        "avatar_dolphin" -> DesignR.drawable.avatar_dolphin
+                        "avatar_whale" -> DesignR.drawable.avatar_whale
+                        "avatar_turtle" -> DesignR.drawable.avatar_turtle
+                        else -> DesignR.drawable.avatar_default
+                    }
+
+                    Image(
+                        painter = painterResource(resId),
+                        contentDescription = null,
                         modifier = Modifier
                             .fillMaxSize()
-                            .clip(CircleShape)
-                            .background(MaterialTheme.colorScheme.primaryContainer),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = displayName.take(1).uppercase(),
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        )
-                    }
+                            .clip(CircleShape),
+                        contentScale = ContentScale.Crop
+                    )
 
                     if (showOnlineStatus && online) {
                         val statusColor = when (onlineStatus) {

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialScreen.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialScreen.kt
@@ -16,11 +16,15 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.Chat
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -304,7 +308,7 @@ private fun FriendRow(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable {
-                    showMenu = true
+                    onViewProfileClick(uid)
                 },
             leadingContent = {
                 Box(
@@ -378,13 +382,28 @@ private fun FriendRow(
                 }
             },
             trailingContent = {
-                if (hasUnreadMessages) {
-                    Box(
-                        modifier = Modifier
-                            .size(10.dp)
-                            .clip(CircleShape)
-                            .background(Color(0xFF2196F3)) // Blue dot
-                    )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    if (hasUnreadMessages) {
+                        Box(
+                            modifier = Modifier
+                                .size(10.dp)
+                                .clip(CircleShape)
+                                .background(Color(0xFF2196F3)) // Blue dot
+                        )
+                    }
+
+                    IconButton(
+                        onClick = { onMessageClick(uid, displayName, avatarId) }
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Rounded.Chat,
+                            contentDescription = "Message",
+                            tint = if (hasUnreadMessages) Color(0xFF2196F3) else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
             }
         )
@@ -393,14 +412,6 @@ private fun FriendRow(
             expanded = showMenu,
             onDismissRequest = { showMenu = false },
         ) {
-            DropdownMenuItem(
-                text = { Text("Message") },
-                onClick = {
-                    showMenu = false
-                    onMessageClick(uid, displayName, avatarId)
-                },
-            )
-
             DropdownMenuItem(
                 text = { Text("View Profile") },
                 onClick = {

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialScreen.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialScreen.kt
@@ -156,6 +156,7 @@ fun SocialScreen(
                         onlineStatus = friend.onlineStatus,
                         lastMessage = friend.lastMessage,
                         hasUnreadMessages = friend.hasUnreadMessages,
+                        unreadCount = friend.unreadCount,
                         onMessageClick = { uid, displayName, avatarId ->
                             onMessageClick(uid, displayName, avatarId)
                         },
@@ -294,6 +295,7 @@ private fun FriendRow(
     onlineStatus: OnlineStatus,
     lastMessage: String,
     hasUnreadMessages: Boolean,
+    unreadCount: Int,
     onMessageClick: (String, String, String) -> Unit,
     onViewProfileClick: (String) -> Unit,
     onRemoveFriendClick: (String) -> Unit,
@@ -308,11 +310,14 @@ private fun FriendRow(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable {
-                    onViewProfileClick(uid)
+                    onMessageClick(uid, displayName, avatarId)
                 },
             leadingContent = {
                 Box(
-                    modifier = Modifier.size(40.dp),
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .clickable { onViewProfileClick(uid) },
                     contentAlignment = Alignment.BottomEnd,
                 ) {
                     val resId = when (avatarId) {
@@ -371,13 +376,34 @@ private fun FriendRow(
                         )
                     }
                     if (lastMessage.isNotBlank()) {
-                        Text(
-                            text = lastMessage,
-                            style = MaterialTheme.typography.bodySmall,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            if (hasUnreadMessages) {
+                                Box(
+                                    modifier = Modifier
+                                        .padding(end = 6.dp)
+                                        .size(8.dp)
+                                        .clip(CircleShape)
+                                        .background(Color(0xFF2196F3))
+                                )
+                            }
+                            val fadeBrush = androidx.compose.ui.graphics.Brush.horizontalGradient(
+                                colors = listOf(
+                                    if (hasUnreadMessages) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant,
+                                    Color.Transparent
+                                ),
+                                startX = 0f,
+                                endX = 600f
+                            )
+                            Text(
+                                text = lastMessage,
+                                style = MaterialTheme.typography.bodySmall.copy(
+                                    brush = fadeBrush,
+                                    fontWeight = if (hasUnreadMessages) androidx.compose.ui.text.font.FontWeight.Bold else androidx.compose.ui.text.font.FontWeight.Normal
+                                ),
+                                maxLines = 1,
+                                overflow = TextOverflow.Clip,
+                            )
+                        }
                     }
                 }
             },
@@ -389,10 +415,18 @@ private fun FriendRow(
                     if (hasUnreadMessages) {
                         Box(
                             modifier = Modifier
-                                .size(10.dp)
                                 .clip(CircleShape)
-                                .background(Color(0xFF2196F3)) // Blue dot
-                        )
+                                .background(Color(0xFF2196F3))
+                                .padding(horizontal = 6.dp, vertical = 2.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "+$unreadCount",
+                                color = Color.White,
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+                            )
+                        }
                     }
 
                     IconButton(

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialScreen.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialScreen.kt
@@ -151,7 +151,6 @@ fun SocialScreen(
                         displayName = friend.displayName,
                         avatarId = friend.avatarId,
                         major = friend.major,
-                        showOnlineStatus = friend.showOnlineStatus,
                         online = friend.online,
                         onlineStatus = friend.onlineStatus,
                         lastMessage = friend.lastMessage,
@@ -290,7 +289,6 @@ private fun FriendRow(
     displayName: String,
     avatarId: String,
     major: String,
-    showOnlineStatus: Boolean,
     online: Boolean,
     onlineStatus: OnlineStatus,
     lastMessage: String,
@@ -342,7 +340,7 @@ private fun FriendRow(
                         )
                     }
 
-                    if (showOnlineStatus && online) {
+                    if (online) {
                         val statusColor = when (onlineStatus) {
                             OnlineStatus.ONLINE -> Color(0xFF4CAF50)
                             OnlineStatus.AWAY -> Color(0xFFFFC107)

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialScreen.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialScreen.kt
@@ -315,26 +315,32 @@ private fun FriendRow(
             leadingContent = {
                 Box(
                     modifier = Modifier
-                        .size(40.dp)
-                        .clip(CircleShape)
-                        .clickable { onViewProfileClick(uid) },
+                        .size(44.dp), // Increased from 40.dp to provide room for indicator
                     contentAlignment = Alignment.BottomEnd,
                 ) {
-                    val resId = when (avatarId) {
-                        "avatar_dolphin" -> DesignR.drawable.avatar_dolphin
-                        "avatar_whale" -> DesignR.drawable.avatar_whale
-                        "avatar_turtle" -> DesignR.drawable.avatar_turtle
-                        else -> DesignR.drawable.avatar_default
-                    }
-
-                    Image(
-                        painter = painterResource(resId),
-                        contentDescription = null,
+                    Box(
                         modifier = Modifier
-                            .fillMaxSize()
-                            .clip(CircleShape),
-                        contentScale = ContentScale.Crop
-                    )
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .clickable { onViewProfileClick(uid) },
+                        contentAlignment = Alignment.BottomEnd,
+                    ) {
+                        val resId = when (avatarId) {
+                            "avatar_dolphin" -> DesignR.drawable.avatar_dolphin
+                            "avatar_whale" -> DesignR.drawable.avatar_whale
+                            "avatar_turtle" -> DesignR.drawable.avatar_turtle
+                            else -> DesignR.drawable.avatar_default
+                        }
+
+                        Image(
+                            painter = painterResource(resId),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clip(CircleShape),
+                            contentScale = ContentScale.Crop
+                        )
+                    }
 
                     if (showOnlineStatus && online) {
                         val statusColor = when (onlineStatus) {
@@ -344,7 +350,7 @@ private fun FriendRow(
                         }
                         Box(
                             modifier = Modifier
-                                .size(12.dp)
+                                .size(14.dp)
                                 .clip(CircleShape)
                                 .background(MaterialTheme.colorScheme.surface)
                                 .padding(2.dp)

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialViewModel.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialViewModel.kt
@@ -87,12 +87,13 @@ class SocialViewModel @Inject constructor(
         val currentUserId = authRepository.getCurrentUserUid() ?: return
 
         viewModelScope.launch {
-            runCatching {
-                val requests = repository.getIncomingRequests(currentUserId)
-                val friends = repository.getFriends(currentUserId)
+            combine(
+                repository.observeIncomingRequests(currentUserId),
+                repository.observeFriends(currentUserId)
+            ) { requests, friends ->
+                requests to friends
+            }.collectLatest { (requests, friends) ->
                 val outgoingRequestIds = repository.getOutgoingRequestIds(currentUserId)
-                Triple(requests, friends, outgoingRequestIds)
-            }.onSuccess { (requests, friends, outgoingRequestIds) ->
                 _uiState.update {
                     it.copy(
                         incomingRequests = requests,
@@ -103,12 +104,6 @@ class SocialViewModel @Inject constructor(
                 }
                 observeFriendPresence(friends)
                 observeFriendMessages(friends)
-            }.onFailure { e ->
-                _uiState.update {
-                    it.copy(
-                        errorMessage = e.message ?: "Failed to load social data",
-                    )
-                }
             }
         }
     }

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialViewModel.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialViewModel.kt
@@ -50,7 +50,7 @@ class SocialViewModel @Inject constructor(
     val uiState: StateFlow<SocialUiState> = _uiState.asStateFlow()
 
     private val queryFlow = MutableStateFlow("")
-    private var presenceJob: Job? = null
+    private var friendsJob: Job? = null
     private var messagesJob: Job? = null
 
     init {
@@ -102,7 +102,7 @@ class SocialViewModel @Inject constructor(
                         errorMessage = null,
                     )
                 }
-                observeFriendPresence(friends)
+                observeFriendLiveUpdates(friends)
                 observeFriendMessages(friends)
             }
         }
@@ -146,36 +146,50 @@ class SocialViewModel @Inject constructor(
         }
     }
 
-    private fun observeFriendPresence(friends: List<FriendUser>) {
-        if (friends.isEmpty()) return
+    private fun observeFriendLiveUpdates(friends: List<FriendUser>) {
+        if (friends.isEmpty()) {
+            friendsJob?.cancel()
+            return
+        }
 
-        presenceJob?.cancel()
-        presenceJob = viewModelScope.launch {
-            val presenceFlows: List<Flow<Pair<String, com.ekhonavigator.core.model.PresenceStatus>>> = friends.map { friend ->
-                presenceRepository.observePresence(friend.uid).map { presence ->
-                    friend.uid to presence
+        friendsJob?.cancel()
+        friendsJob = viewModelScope.launch {
+            val friendFlows = friends.map { friend ->
+                combine(
+                    repository.observeUser(friend.uid),
+                    presenceRepository.observePresence(friend.uid)
+                ) { user, presence ->
+                    Triple(friend.uid, user, presence)
                 }
             }
 
-            combine(presenceFlows) { friendPresences: Array<Pair<String, com.ekhonavigator.core.model.PresenceStatus>> ->
-                friendPresences.toMap()
+            combine(friendFlows) { updates ->
+                updates.toList()
             }.catch { e ->
-                _uiState.update { it.copy(errorMessage = "Error observing presence: ${e.message}") }
-            }.collectLatest { presenceMap ->
+                _uiState.update { it.copy(errorMessage = "Error observing friend updates: ${e.message}") }
+            }.collectLatest { updates ->
                 _uiState.update { state ->
                     val updatedFriends = state.friends.map { friend ->
-                        val presence = presenceMap[friend.uid]
-                        if (presence != null) {
-                            val statusStr = presence.state.uppercase()
+                        val update = updates.find { it.first == friend.uid }
+                        val user = update?.second
+                        val presence = update?.third
+
+                        if (user != null) {
+                            val statusStr = presence?.state?.uppercase() ?: "OFFLINE"
                             val onlineStatus = try {
                                 OnlineStatus.valueOf(statusStr)
                             } catch (e: Exception) {
                                 OnlineStatus.ONLINE
                             }
+
                             friend.copy(
-                                online = presence.state != "offline",
+                                displayName = user.displayName,
+                                avatarId = user.avatarId,
+                                major = user.major,
+                                showOnlineStatus = user.showOnlineStatus,
+                                online = presence?.state != "offline",
                                 onlineStatus = onlineStatus,
-                                lastChanged = presence.lastChanged
+                                lastChanged = presence?.lastChanged ?: 0L
                             )
                         } else {
                             friend

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialViewModel.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/SocialViewModel.kt
@@ -123,20 +123,27 @@ class SocialViewModel @Inject constructor(
                     _uiState.update { it.copy(errorMessage = "Error observing messages: ${e.message}") }
                 }
                 .collectLatest { conversations ->
-                    val unreadMap = conversations.associateBy(
+                    val conversationMap = conversations.associateBy(
                         keySelector = { conv ->
                             conv.participantIds.find { it != currentUserId } ?: ""
-                        },
-                        valueTransform = { conv ->
-                            conv.lastSenderId != currentUserId && !conv.readBy.contains(currentUserId)
                         }
                     )
 
                     _uiState.update { state ->
                         val updatedFriends = state.friends.map { friend ->
-                            friend.copy(
-                                hasUnreadMessages = unreadMap[friend.uid] == true
-                            )
+                            val conv = conversationMap[friend.uid]
+                            if (conv != null) {
+                                val isUnread = conv.lastSenderId != currentUserId && (conv.unreadCount > 0 || !conv.readBy.contains(currentUserId))
+                                friend.copy(
+                                    lastMessage = conv.lastMessage,
+                                    lastMessageTimestamp = conv.lastTimestamp,
+                                    lastMessageSenderId = conv.lastSenderId,
+                                    hasUnreadMessages = isUnread,
+                                    unreadCount = if (isUnread) conv.unreadCount.coerceAtLeast(1) else 0
+                                )
+                            } else {
+                                friend
+                            }
                         }
                         state.copy(friends = updatedFriends)
                     }

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/UserProfileScreen.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/UserProfileScreen.kt
@@ -5,21 +5,31 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.PersonRemove
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -33,13 +43,40 @@ import com.ekhonavigator.core.model.OnlineStatus
 @Composable
 fun UserProfileScreen(
     userId: String,
+    onBack: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: UserProfileViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    var showDeleteDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(userId) {
         viewModel.loadUserProfile(userId)
+    }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("Delete Friend?") },
+            text = { Text("Are you sure? We won't tell the other person, but in order to message them again you will have to send them a new friend request.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteDialog = false
+                        viewModel.removeFriend(userId) {
+                            onBack()
+                        }
+                    }
+                ) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
     }
 
     when {
@@ -74,6 +111,23 @@ fun UserProfileScreen(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    if (uiState.isFriend) {
+                        TextButton(
+                            onClick = { showDeleteDialog = true },
+                            modifier = Modifier.align(Alignment.TopStart)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.PersonRemove,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            androidx.compose.foundation.layout.Spacer(modifier = Modifier.size(8.dp))
+                            Text("Remove Friend", color = MaterialTheme.colorScheme.error)
+                        }
+                    }
+                }
+
                 Box(
                     contentAlignment = Alignment.BottomEnd,
                 ) {
@@ -108,23 +162,17 @@ fun UserProfileScreen(
                     }
                 }
 
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(),
-                ) {
-                    Column(
-                        modifier = Modifier.padding(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        Text(
-                            text = "Display Name",
-                            style = MaterialTheme.typography.titleMedium,
-                        )
-                        Text(
-                            text = user.displayName,
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    }
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = user.displayName,
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                    )
+                    Text(
+                        text = user.email,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
 
                 if (user.majorVisible && user.major.isNotBlank()) {

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/UserProfileViewModel.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/UserProfileViewModel.kt
@@ -45,29 +45,28 @@ class UserProfileViewModel @Inject constructor(
                 )
             }
 
+            launch {
+                repository.observeUser(userId).collect { user ->
+                    _uiState.update { it.copy(user = user, isLoading = false) }
+                }
+            }
+
             try {
-                val user = repository.getUserById(userId)
                 val currentUserId = authRepository.getCurrentUserUid()
                 val friends = if (currentUserId != null) repository.getFriends(currentUserId) else emptyList()
                 val isFriend = friends.any { it.uid == userId }
 
                 _uiState.update {
                     it.copy(
-                        isLoading = false,
-                        user = user,
                         isFriend = isFriend,
-                        errorMessage = if (user == null) "User not found" else null,
                     )
                 }
 
-                if (user != null) {
-                    observePresence(userId)
-                }
+                observePresence(userId)
             } catch (e: Exception) {
                 _uiState.update {
                     it.copy(
                         isLoading = false,
-                        user = null,
                         errorMessage = e.message ?: "Failed to load profile",
                     )
                 }

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/UserProfileViewModel.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/UserProfileViewModel.kt
@@ -2,6 +2,7 @@ package com.ekhonavigator.feature.social
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ekhonavigator.core.data.auth.AuthRepository
 import com.ekhonavigator.core.data.social.SocialRepository
 import com.ekhonavigator.core.data.social.SocialUser
 import com.ekhonavigator.core.data.repository.PresenceRepository
@@ -21,12 +22,14 @@ data class UserProfileUiState(
     val onlineStatus: OnlineStatus = OnlineStatus.ONLINE,
     val lastSeen: Long = 0L,
     val errorMessage: String? = null,
+    val isFriend: Boolean = false,
 )
 
 @HiltViewModel
 class UserProfileViewModel @Inject constructor(
     private val repository: SocialRepository,
     private val presenceRepository: PresenceRepository,
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(UserProfileUiState())
@@ -44,11 +47,15 @@ class UserProfileViewModel @Inject constructor(
 
             try {
                 val user = repository.getUserById(userId)
+                val currentUserId = authRepository.getCurrentUserUid()
+                val friends = if (currentUserId != null) repository.getFriends(currentUserId) else emptyList()
+                val isFriend = friends.any { it.uid == userId }
 
                 _uiState.update {
                     it.copy(
                         isLoading = false,
                         user = user,
+                        isFriend = isFriend,
                         errorMessage = if (user == null) "User not found" else null,
                     )
                 }
@@ -64,6 +71,18 @@ class UserProfileViewModel @Inject constructor(
                         errorMessage = e.message ?: "Failed to load profile",
                     )
                 }
+            }
+        }
+    }
+
+    fun removeFriend(friendUserId: String, onSuccess: () -> Unit) {
+        val currentUserId = authRepository.getCurrentUserUid() ?: return
+        viewModelScope.launch {
+            try {
+                repository.removeFriend(currentUserId, friendUserId)
+                onSuccess()
+            } catch (e: Exception) {
+                _uiState.update { it.copy(errorMessage = e.message ?: "Failed to remove friend") }
             }
         }
     }

--- a/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/navigation/SocialNavKey.kt
+++ b/feature/social/src/main/kotlin/com/ekhonavigator/feature/social/navigation/SocialNavKey.kt
@@ -46,6 +46,7 @@ fun EntryProviderScope<NavKey>.socialEntry(navigator: Navigator, onNavigateToMap
     entry<UserProfileNavKey> { key ->
         UserProfileScreen(
             userId = key.userId,
+            onBack = { navigator.goBack() }
         )
     }
 


### PR DESCRIPTION
UI changes to social tab, friend pfp's now sync to actual user, friend tile functionality changed so now on click of pfp it brings up user profile and on click of tile body it brings up messages, notification dot on social nav key for new undread message, notification dot on freind who sent message along with message preview and a unread message counter. Overhaulled friend list user accct state info to get rid of stale data and one time reads along with redundant checks 