### PR TITLE
feat(map): add dark mode map styling and clean up hint popup layout

### DIFF
--- a/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/LocationDetailComponents.kt
+++ b/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/LocationDetailComponents.kt
@@ -28,10 +28,6 @@ import androidx.compose.ui.window.DialogProperties
 
 @Composable
 fun CampusPlacePreviewCard(place: CampusPlace) {
-    // No Card wrapper — Google Maps' SDK draws the surrounding white tooltip already,
-    // and an inner themed Card was rendering as a black box on top of it in dark mode.
-    // Text colors are fixed near-black/gray to read on the SDK's white background in
-    // both light and dark mode.
     Column(
         modifier = Modifier
             .padding(16.dp)
@@ -43,13 +39,13 @@ fun CampusPlacePreviewCard(place: CampusPlace) {
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.ExtraBold,
             textAlign = TextAlign.Center,
-            color = InfoWindowPrimary,
+            color = MaterialTheme.colorScheme.onSurface,
         )
 
         Text(
             text = place.category.label.uppercase(),
             style = MaterialTheme.typography.labelSmall,
-            color = InfoWindowSecondary,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
             fontWeight = FontWeight.ExtraBold,
             modifier = Modifier.padding(top = 2.dp)
         )
@@ -61,13 +57,13 @@ fun CampusPlacePreviewCard(place: CampusPlace) {
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold,
             textAlign = TextAlign.Center,
-            color = InfoWindowPrimary,
+            color = MaterialTheme.colorScheme.onSurface,
         )
 
         Text(
             text = place.fullLocationDescription,
             style = MaterialTheme.typography.bodySmall,
-            color = InfoWindowSecondary,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
             modifier = Modifier.padding(top = 4.dp)
         )
@@ -145,10 +141,16 @@ fun CampusPlaceDetailCard(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         androidx.compose.material3.IconButton(onClick = onGetWalkingDirections) {
-                            Icon(imageVector = androidx.compose.material.icons.Icons.Default.DirectionsWalk, contentDescription = "Walk")
+                            Icon(
+                                imageVector = androidx.compose.material.icons.Icons.Default.DirectionsWalk,
+                                contentDescription = "Walk"
+                            )
                         }
                         androidx.compose.material3.IconButton(onClick = onGetDrivingDirections) {
-                            Icon(imageVector = androidx.compose.material.icons.Icons.Default.DirectionsCar, contentDescription = "Drive")
+                            Icon(
+                                imageVector = androidx.compose.material.icons.Icons.Default.DirectionsCar,
+                                contentDescription = "Drive"
+                            )
                         }
                     }
 

--- a/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/MapScreen.kt
@@ -1,5 +1,7 @@
 package com.ekhonavigator.feature.map
 
+import androidx.compose.foundation.isSystemInDarkTheme
+import com.google.android.gms.maps.model.MapStyleOptions
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
@@ -194,6 +196,12 @@ fun MapScreen(
         position = CameraPosition.fromLatLngZoom(csuciCenter, 15f)
     }
 
+    val mapStyle = if (isSystemInDarkTheme()) {
+        MapStyleOptions.loadRawResourceStyle(context, R.raw.map_style_dark)
+    } else {
+        null
+    }
+
     var isMapLoaded by remember { mutableStateOf(false) }
 
     // Animate (not initial position) — contentPadding is only honored on CameraUpdate moves.
@@ -326,6 +334,7 @@ fun MapScreen(
             cameraPositionState = cameraPositionState,
             contentPadding = mapPaddingForInfoCards,
             properties = MapProperties(
+                mapStyleOptions = mapStyle,
                 isMyLocationEnabled = hasLocationPermission &&
                         !isAnyMarkerInfoShowing &&
                         selectedCampusPlace == null &&
@@ -539,7 +548,7 @@ fun MapScreen(
                     shadowElevation = 4.dp
                 ) {
                     Row(
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Column(
@@ -548,15 +557,17 @@ fun MapScreen(
                         ) {
                             Text(
                                 text = "Zoom in to see points of interest. Click filters to see even more.",
-                                style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.5.sp),
+                                style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp, lineHeight = 14.sp),
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                textAlign = TextAlign.Center
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.fillMaxWidth()
                             )
                             Text(
                                 text = "Hold anywhere on the map to drop a custom marker.",
-                                style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.5.sp),
+                                style = MaterialTheme.typography.labelSmall.copy(fontSize = 11.sp),
                                 color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                textAlign = TextAlign.Center
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.fillMaxWidth()
                             )
                         }
                         Spacer(modifier = Modifier.size(8.dp))

--- a/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/MapScreen.kt
+++ b/feature/map/src/main/kotlin/com/ekhonavigator/feature/map/MapScreen.kt
@@ -73,7 +73,7 @@ import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.Marker
-import com.google.maps.android.compose.MarkerInfoWindowContent
+import com.google.maps.android.compose.MarkerInfoWindow
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberMarkerState
 import kotlinx.coroutines.delay
@@ -90,12 +90,6 @@ data class UserMarker(
 // UserDroppedMarkers as Place entries — the navigated focusPlaceId arrives
 // from the event WHERE row in that namespaced form.
 private const val MARKER_FOCUS_PREFIX = "marker_"
-
-// Google Maps' InfoWindow draws a white tooltip background regardless of app theme
-// (the SDK snapshots the content into a Bitmap, so MaterialTheme can't override it).
-// These are fixed dark text colors that read on that white in both light and dark mode.
-internal val InfoWindowPrimary = androidx.compose.ui.graphics.Color(0xFF1A1A1A)
-internal val InfoWindowSecondary = androidx.compose.ui.graphics.Color(0xFF606060)
 
 // - MAP CONTROLS
 @Composable
@@ -368,7 +362,7 @@ fun MapScreen(
                                 markerState.showInfoWindow()
                             }
                         }
-                        MarkerInfoWindowContent(
+                        MarkerInfoWindow(
                             state = markerState,
                             onClick = {
                                 isAnyMarkerInfoShowing = true
@@ -376,10 +370,18 @@ fun MapScreen(
                             },
                             onInfoWindowClick = {
                                 selectedCampusPlace = place
+                            },
+                            content = {
+                                Surface(
+                                    shape = MaterialTheme.shapes.medium,
+                                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                    tonalElevation = 4.dp,
+                                    shadowElevation = 4.dp
+                                ) {
+                                    CampusPlacePreviewCard(place = place)
+                                }
                             }
-                        ) {
-                            CampusPlacePreviewCard(place = place)
-                        }
+                        )
                     }
                 }
             }
@@ -393,7 +395,7 @@ fun MapScreen(
                             markerState.showInfoWindow()
                         }
                     }
-                    MarkerInfoWindowContent(
+                    MarkerInfoWindow(
                         state = markerState,
                         icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE),
                         onInfoWindowClick = {
@@ -401,29 +403,33 @@ fun MapScreen(
                         },
                         onInfoWindowLongClick = {
                             selectedDroppedMarkerForOptions = droppedMarker
+                        },
+                        content = {
+                            Surface(
+                                shape = MaterialTheme.shapes.small,
+                                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                tonalElevation = 4.dp
+                            ) {
+                                Column(
+                                    modifier = Modifier.padding(8.dp),
+                                    horizontalAlignment = Alignment.CenterHorizontally
+                                ) {
+                                    Text(
+                                        text = droppedMarker.markerLabelComment.ifBlank { "Dropped Marker" },
+                                        textAlign = TextAlign.Center,
+                                        style = MaterialTheme.typography.labelLarge,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                    )
+                                    Text(
+                                        text = "Tap bubble for options (edit/remove)",
+                                        textAlign = TextAlign.Center,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
                         }
-                    ) {
-                        // No Card wrapper — Google Maps' SDK draws the surrounding white
-                        // tooltip already, and an inner Card was rendering as a black box
-                        // on top of it in dark mode.
-                        Column(
-                            modifier = Modifier.padding(8.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            Text(
-                                text = droppedMarker.markerLabelComment.ifBlank { "Dropped Marker" },
-                                textAlign = TextAlign.Center,
-                                style = MaterialTheme.typography.labelLarge,
-                                color = InfoWindowPrimary,
-                            )
-                            Text(
-                                text = "Tap bubble for options (edit/remove)",
-                                textAlign = TextAlign.Center,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = InfoWindowSecondary,
-                            )
-                        }
-                    }
+                    )
                 }
             }
             if (activeRoutePoints.isNotEmpty()) {

--- a/feature/map/src/main/res/raw/map_style_dark.json
+++ b/feature/map/src/main/res/raw/map_style_dark.json
@@ -1,0 +1,84 @@
+[
+  {
+    "elementType": "geometry",
+    "stylers": [{ "color": "#242f3e" }]
+  },
+  {
+    "elementType": "labels.text.stroke",
+    "stylers": [{ "color": "#242f3e" }]
+  },
+  {
+    "elementType": "labels.text.fill",
+    "stylers": [{ "color": "#746855" }]
+  },
+  {
+    "featureType": "administrative.locality",
+    "elementType": "labels.text.fill",
+    "stylers": [{ "color": "#d59563" }]
+  },
+  {
+    "featureType": "poi",
+    "elementType": "labels.text.fill",
+    "stylers": [{ "color": "#d59563" }]
+  },
+  {
+    "featureType": "poi.park",
+    "elementType": "geometry",
+    "stylers": [{ "color": "#263c3f" }]
+  },
+  {
+    "featureType": "road",
+    "elementType": "geometry",
+    "stylers": [{ "color": "#38414e" }]
+  },
+  {
+    "featureType": "road",
+    "elementType": "geometry.stroke",
+    "stylers": [{ "color": "#212a37" }]
+  },
+  {
+    "featureType": "road",
+    "elementType": "labels.text.fill",
+    "stylers": [{ "color": "#9ca5b3" }]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "geometry",
+    "stylers": [{ "color": "#746855" }]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "geometry.stroke",
+    "stylers": [{ "color": "#1f2835" }]
+  },
+  {
+    "featureType": "road.highway",
+    "elementType": "labels.text.fill",
+    "stylers": [{ "color": "#f3d19c" }]
+  },
+  {
+    "featureType": "transit",
+    "elementType": "geometry",
+    "stylers": [{ "color": "#2f3948" }]
+  },
+  {
+    "featureType": "transit.station",
+    "elementType": "labels.text.fill",
+    "stylers": [{ "color": "#d59563" }]
+  },
+  {
+    "featureType": "water",
+    "elementType": "geometry",
+    "stylers": [{ "color": "#17263c" }]
+  },
+  {
+    "featureType": "water",
+    "elementType": "labels.text.fill",
+    "stylers": [{ "color": "#515c6d" }]
+  },
+  {
+    "featureType": "water",
+    "elementType": "labels.text.stroke",
+    "stylers": [{ "color": "#17263c" }]
+  }
+]


### PR DESCRIPTION
•Added automatic dark mode styling for Google Maps with custom JSON map styles. 
•Adjusted the hint popup spacing and text sizing so the message wraps better. 
•Made sure the map styling follows the system dark theme correctly.